### PR TITLE
fix/typescript-exports

### DIFF
--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -1,8 +1,8 @@
-import Ethereum from "@irys/upload-ethereum"
-import NodeIrys from "@irys/upload"
+import {Ethereum} from "@irys/upload-ethereum"
+import {Uploader} from "@irys/upload"
 (async function(){
 
-    const client = await new NodeIrys(Ethereum).withWallet("...").build()
+    const client = await Uploader(Ethereum).withWallet("...").build()
     console.log(client)
     const res = await client.upload("test", {tags: [{name: "hello", value: "world"}]});
     console.log(res)

--- a/packages/aptos-node/CHANGELOG.md
+++ b/packages/aptos-node/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @irys/upload-aptos
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @irys/upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -9,5 +16,3 @@
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
   - @irys/upload@0.0.1
-
-

--- a/packages/aptos-node/package.json
+++ b/packages/aptos-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/upload-aptos",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Aptos NodeJS token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/aptos-web/CHANGELOG.md
+++ b/packages/aptos-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @irys/web-upload-aptos
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/web-upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/packages/aptos-web/package.json
+++ b/packages/aptos-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload-aptos",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Aptos web token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/aptos-web/src/token.ts
+++ b/packages/aptos-web/src/token.ts
@@ -15,7 +15,7 @@ import {
 import type { Signer } from "@irys/bundles";
 import { InjectedAptosSigner, AptosSigner } from "@irys/bundles/web";
 import BigNumber from "bignumber.js";
-import type { TokenConfig, Tx } from "@irys/upload-core/types";
+import type { TokenConfig, Tx } from "@irys/upload-core";
 import sha3 from "js-sha3";
 import BaseWebToken from "@irys/web-upload/tokens/base";
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @irys/upload-cli
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @irys/upload-solana@0.0.2
+  - @irys/upload@0.0.2
+  - @irys/upload-ethereum@0.0.2
+  - @irys/upload-aptos@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -12,4 +22,3 @@
   - @irys/upload@0.0.1
   - @irys/upload-aptos@0.0.1
   - @irys/upload-ethereum@0.0.1
-

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "NodeJS multi-token CLI for the Irys network",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/ethereum-ethers-v6/CHANGELOG.md
+++ b/packages/ethereum-ethers-v6/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @irys/web-upload-ethereum-ethers-v6
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/web-upload-ethereum@0.0.2
+  - @irys/web-upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -10,4 +20,3 @@
   - @irys/web-upload-ethereum@0.0.1
   - @irys/upload-core@0.0.1
   - @irys/web-upload@0.0.1
-

--- a/packages/ethereum-ethers-v6/package.json
+++ b/packages/ethereum-ethers-v6/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload-ethereum-ethers-v6",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Provider adapter library for adapting ethersv6 providers for use with the web Ethereum Irys bundler token client",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/ethereum-ethers-v6/src/adapter.ts
+++ b/packages/ethereum-ethers-v6/src/adapter.ts
@@ -2,7 +2,7 @@ import type { InjectedTypedEthereumSignerMinimalSigner } from "@irys/bundles/web
 import BigNumber from "bignumber.js";
 import { BigNumber as EthBigNumber } from "@ethersproject/bignumber";
 import type { BrowserProvider, JsonRpcSigner, TypedDataDomain } from "ethers";
-import type { Tx } from "@irys/upload-core/types";
+import type { Tx } from "@irys/upload-core";
 import {EthereumConfig, type MinimalProvider} from "@irys/web-upload-ethereum/ethereum";
 
 export const getV6Adapter  = (base: {new(...args: any): EthereumConfig}): {new(...args: any): EthereumConfig} => {

--- a/packages/ethereum-viem-v2/CHANGELOG.md
+++ b/packages/ethereum-viem-v2/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @irys/web-upload-ethereum-viem-v2
 
+## 0.0.3
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/web-upload-ethereum@0.0.2
+  - @irys/web-upload@0.0.2
+
 ## 0.0.2
 
 ### Patch Changes

--- a/packages/ethereum-viem-v2/package.json
+++ b/packages/ethereum-viem-v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload-ethereum-viem-v2",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Provider adapter library for adapting Viem v2 providers for use with the web Ethereum Irys bundler token client",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/ethereum-viem-v2/src/adapter.ts
+++ b/packages/ethereum-viem-v2/src/adapter.ts
@@ -1,5 +1,5 @@
 import BigNumber from "bignumber.js";
-import type { Tx } from "@irys/upload-core/types";
+import type { Tx } from "@irys/upload-core";
 import {EthereumConfig} from "@irys/web-upload-ethereum/ethereum";
 import type { http } from "viem";
 import type { PublicClient, WalletClient } from "viem";

--- a/packages/ethereum-web/CHANGELOG.md
+++ b/packages/ethereum-web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @irys/web-upload-ethereum
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/web-upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -9,4 +18,3 @@
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
   - @irys/web-upload@0.0.1
-

--- a/packages/ethereum-web/package.json
+++ b/packages/ethereum-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload-ethereum",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Ethereum web token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/ethereum-web/src/clients.ts
+++ b/packages/ethereum-web/src/clients.ts
@@ -103,5 +103,5 @@ export const WebIotex: Constructable<[TokenConfigTrimmed], BaseWebToken> = getBo
 //     return new Builder(EthereumToken)/* .withTokenOptions(opts) */
 // }
 // export const WebMatic: Constructable<[TokenConfigTrimmed], BaseWebToken> = getBoundEth({name: "matic", ticker: "MATIC", providerUrl: "https://polygon-rpc.com/" })
-export const WebEthereum = EthereumToken
+export const WebEthereum: Constructable<[TokenConfigTrimmed], BaseWebToken> =   EthereumToken
 export default WebEthereum

--- a/packages/ethereum-web/src/erc20.ts
+++ b/packages/ethereum-web/src/erc20.ts
@@ -1,6 +1,6 @@
 import BigNumber from "bignumber.js";
 import { Contract } from "@ethersproject/contracts";
-import type { TokenConfig, Tx } from "@irys/upload-core/types";
+import type { TokenConfig, Tx } from "@irys/upload-core";
 import EthereumConfig from "./ethereum";
 
 export interface ERC20TokenConfig extends TokenConfig {

--- a/packages/ethereum-web/src/ethereum.ts
+++ b/packages/ethereum-web/src/ethereum.ts
@@ -1,7 +1,7 @@
 import type { JsonRpcSigner, TransactionRequest, Web3Provider } from "@ethersproject/providers";
 import { BigNumber as EthBigNumber } from "@ethersproject/bignumber";
 import BigNumber from "bignumber.js";
-import type { Tx, TokenConfig } from "@irys/upload-core/types";
+import type { Tx, TokenConfig } from "@irys/upload-core";
 import {BaseWebToken} from "@irys/web-upload/tokens/base";
 import { InjectedTypedEthereumSigner, type InjectedTypedEthereumSignerMinimalSigner } from "@irys/bundles/web";
 

--- a/packages/ethereum/CHANGELOG.md
+++ b/packages/ethereum/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @irys/upload-ethereum
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -9,4 +18,3 @@
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
   - @irys/upload@0.0.1
-

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/upload-ethereum",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Ethereum NodeJS token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/ethereum/src/erc20.ts
+++ b/packages/ethereum/src/erc20.ts
@@ -4,7 +4,7 @@ import { Wallet } from "@ethersproject/wallet";
 import { keccak256 } from "@irys/bundles";
 import { getRedstonePrice } from "@irys/upload/tokens/base";
 import EthereumConfig from "./ethereum";
-import type { TokenConfig, Tx } from "@irys/upload-core/types";
+import type { TokenConfig, Tx } from "@irys/upload-core";
 export interface ERC20TokenConfig extends TokenConfig {
   contractAddress: string;
 }

--- a/packages/ethereum/src/ethereum.ts
+++ b/packages/ethereum/src/ethereum.ts
@@ -4,7 +4,7 @@ import { Wallet } from "@ethersproject/wallet";
 import BigNumber from "bignumber.js";
 import { EthereumSigner, keccak256 } from "@irys/bundles";
 import type { Signer } from "@irys/bundles";
-import type { TokenConfig, Tx } from "@irys/upload-core/types";
+import type { TokenConfig, Tx } from "@irys/upload-core";
 import { BaseNodeToken } from "@irys/upload/tokens/base";
 
 const ethereumSigner = EthereumSigner;

--- a/packages/readme.md
+++ b/packages/readme.md
@@ -1,0 +1,9 @@
+# Irys JS SDK monorepository
+This monorepo contains all the packages that comprise the Irys JS SDK
+
+
+
+## Developer notes
+
+Some important 'gotchas':
+- While Node.JS/bundlers will resolve code through package.json export paths, Typescript *will NOT if it's moduleResolution is node* - so make sure all public facing types are exported/imported through index.ts barrel files.

--- a/packages/solana-node/CHANGELOG.md
+++ b/packages/solana-node/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @irys/upload-solana
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
+- Updated dependencies []:
+  - @irys/upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -9,4 +18,3 @@
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
   - @irys/upload@0.0.1
-

--- a/packages/solana-node/package.json
+++ b/packages/solana-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/upload-solana",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Solana NodeJS token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/solana-node/src/token.ts
+++ b/packages/solana-node/src/token.ts
@@ -3,7 +3,7 @@ import { HexSolanaSigner } from "@irys/bundles";
 import BigNumber from "bignumber.js";
 import bs58 from "bs58";
 import nacl from "tweetnacl";
-import type { TokenConfig, Tx } from "@irys/upload-core/types";
+import type { TokenConfig, Tx } from "@irys/upload-core";
 import { BaseNodeToken } from "@irys/upload/tokens/base";
 import retry from "async-retry";
 import type { Finality } from "@solana/web3.js";

--- a/packages/solana-web/CHANGELOG.md
+++ b/packages/solana-web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @irys/web-upload-solana
 
+## 0.0.2
+
+### Patch Changes
+
+- Updated dependencies []:
+  - @irys/web-upload@0.0.2
+
 ## 0.0.1
 
 ### Patch Changes
@@ -9,4 +16,3 @@
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
   - @irys/web-upload@0.0.1
-

--- a/packages/solana-web/package.json
+++ b/packages/solana-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload-solana",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Solana web token client for Irys network bundlers",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/upload-node/CHANGELOG.md
+++ b/packages/upload-node/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @irys/upload
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
 ## 0.0.1
 
 ### Patch Changes
@@ -8,4 +14,3 @@
 
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
-

--- a/packages/upload-node/package.json
+++ b/packages/upload-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/upload",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "NodeJS token-agnostic library for Irys network bundler clients",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/upload-node/src/base.ts
+++ b/packages/upload-node/src/base.ts
@@ -1,14 +1,8 @@
 import "@irys/upload-core/hack"
-import { Transaction } from "@irys/upload-core/transactions";
-import Api from "@irys/upload-core/api";
-import Fund from "@irys/upload-core/fund";
-import {Irys} from "@irys/upload-core/irys";
-import type { CreateAndUploadOptions, IrysConfig, Network, UploadResponse } from "@irys/upload-core/types";
-import Utils from "@irys/upload-core/utils";
+import {Irys, Api, Fund, Transaction, type CreateAndUploadOptions, type IrysConfig, type Network, type UploadResponse, Utils, Approval} from "@irys/upload-core";
 import type { NodeToken } from "./types";
 import NodeUploader from "./upload";
 import * as bundles from "./utils";
-import { Approval } from "@irys/upload-core/approval";
 import { Resolvable } from "./builder";
 
 export class BaseNodeIrys extends Irys {

--- a/packages/upload-node/src/builder.ts
+++ b/packages/upload-node/src/builder.ts
@@ -70,6 +70,7 @@ export class UploadBuilder {
     }
 
     public withWallet(wallet: any){
+        if(!wallet) throw new Error("Provided wallet is undefined")
         this.wallet = wallet;
         return this
     }

--- a/packages/upload-node/src/builder.ts
+++ b/packages/upload-node/src/builder.ts
@@ -1,5 +1,5 @@
 import {  IrysConfig, Network
- } from "@irys/upload-core/types";
+ } from "@irys/upload-core";
 import { NodeIrysConfig, NodeToken } from "./types";
 import {BaseNodeIrys} from "./base";
 import { Irys } from "@irys/upload-core";
@@ -100,7 +100,7 @@ export class UploadBuilder {
         return this
     }
 
-    public async build() {
+    public async build(): Promise<BaseNodeIrys> {
 
         const irys = new BaseNodeIrys({
             url: this.config.url,

--- a/packages/upload-node/src/tokens/base.ts
+++ b/packages/upload-node/src/tokens/base.ts
@@ -1,6 +1,6 @@
 import type { Signer } from "@irys/bundles";
 import type BigNumber from "bignumber.js";
-import type { Tx, TokenConfig } from "@irys/upload-core/types";
+import type { Tx, TokenConfig } from "@irys/upload-core";
 import axios from "axios";
 import type { NodeToken } from "../types";
 import utils from "@irys/upload-core/utils";

--- a/packages/upload-node/src/types.ts
+++ b/packages/upload-node/src/types.ts
@@ -1,4 +1,4 @@
-import type { IrysConfig, Network, Token } from "@irys/upload-core/types";
+import type { IrysConfig, Network, Token } from "@irys/upload-core";
 import BaseNodeIrys from "./base";
 export interface NodeToken extends Token {
   getPublicKey(): string | Buffer;

--- a/packages/upload-node/src/upload.ts
+++ b/packages/upload-node/src/upload.ts
@@ -1,6 +1,6 @@
 import type { PathLike } from "fs";
 import { promises, createReadStream, createWriteStream } from "fs";
-import type { CreateAndUploadOptions, Token, IrysTransactonCtor, UploadReceipt, UploadResponse, Tags } from "@irys/upload-core/types";
+import type { CreateAndUploadOptions, Token, IrysTransactonCtor, UploadReceipt, UploadResponse, Tags } from "@irys/upload-core";
 import Uploader from "@irys/upload-core/upload";
 import type Api from "@irys/upload-core/api";
 import type Utils from "@irys/upload-core/utils";

--- a/packages/upload-web/CHANGELOG.md
+++ b/packages/upload-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @irys/web-upload
 
+## 0.0.2
+
+### Patch Changes
+
+- Fix use of export paths for TypeScript
+
 ## 0.0.1
 
 ### Patch Changes
@@ -8,4 +14,3 @@
 
 - Updated dependencies []:
   - @irys/upload-core@0.0.1
-

--- a/packages/upload-web/package.json
+++ b/packages/upload-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@irys/web-upload",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Web token-agnostic library for Irys network bundler clients",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/upload-web/src/base.ts
+++ b/packages/upload-web/src/base.ts
@@ -1,14 +1,8 @@
 import "@irys/upload-core/hack";
-import Api from "@irys/upload-core/api";
-import Fund from "@irys/upload-core/fund";
-import Irys from "@irys/upload-core/irys";
-import Utils from "@irys/upload-core/utils";
-import { Transaction } from "@irys/upload-core/transactions";
+import {Irys, Utils, Api, Fund, Transaction, Approval, type IrysConfig, type Network } from "@irys/upload-core";
 import type { WebToken } from "./types";
 import * as bundles from "./utils";
 import { WebUploader } from "./upload";
-import type { IrysConfig, Network } from "@irys/upload-core/types";
-import { Approval } from "@irys/upload-core/approval";
 import { Resolvable } from "./builder";
 
 export class BaseWebIrys extends Irys {

--- a/packages/upload-web/src/builder.ts
+++ b/packages/upload-web/src/builder.ts
@@ -1,4 +1,4 @@
-import { IrysConfig, Network} from "@irys/upload-core/types";
+import { IrysConfig, Network} from "@irys/upload-core";
 import { WebIrysConfig, WebToken } from "./types";
 import {BaseWebIrys} from "./base";
 import { Irys } from "@irys/upload-core";

--- a/packages/upload-web/src/tokens/base.ts
+++ b/packages/upload-web/src/tokens/base.ts
@@ -1,6 +1,6 @@
 import type { Signer } from "@irys/bundles";
 import type BigNumber from "bignumber.js";
-import type { Tx, TokenConfig } from "@irys/upload-core/types";
+import type { Tx, TokenConfig } from "@irys/upload-core";
 import axios from "axios";
 import type { WebToken } from "../types";
 import utils from "@irys/upload-core/utils";

--- a/packages/upload-web/src/types.ts
+++ b/packages/upload-web/src/types.ts
@@ -1,4 +1,4 @@
-import type { IrysConfig, Network, Token } from "@irys/upload-core/types";
+import type { IrysConfig, Network, Token } from "@irys/upload-core";
 
 export interface WebToken extends Token {
   getPublicKey(): Promise<string | Buffer>;

--- a/packages/upload-web/src/upload.ts
+++ b/packages/upload-web/src/upload.ts
@@ -1,5 +1,5 @@
 import Uploader from "@irys/upload-core/upload";
-import type { CreateAndUploadOptions, Manifest, UploadOptions, UploadResponse } from "@irys/upload-core/types";
+import type { CreateAndUploadOptions, Manifest, UploadOptions, UploadResponse } from "@irys/upload-core";
 import type { DataItem, JWKInterface, Tag } from "@irys/bundles";
 import { ArweaveSigner } from "@irys/bundles";
 import BaseWebIrys from "./base";


### PR DESCRIPTION
This PR fixes an issue with typescript discovering types imported through an export path, i.e `@irys/upload-core/types`, instead of from the root/barrel file `@irys/upload-core`.